### PR TITLE
libpkg: fix buffer overlow during `sipkey` init

### DIFF
--- a/libpkg/pkg_jobs_conflicts.c
+++ b/libpkg/pkg_jobs_conflicts.c
@@ -57,8 +57,9 @@ pkg_conflicts_sipkey_init(void)
 		arc4random_buf((unsigned char*)kinit, sizeof(*kinit));
 #else
 		srand((unsigned int) time(NULL));
+		unsigned char* out = (unsigned char*)kinit;
 		for (size_t i = 0; i < sizeof(*kinit); i++)
-			*(int *)(kinit + i) = rand();
+			out[i] = (unsigned char)rand();
 #endif
 	}
 


### PR DESCRIPTION
the issue here was that `kinit` was casted to `int *` then i * sizeof(int) bytes where written into the "buffer". this overflowed into the root-node of the avl tree. of course, thanks to the randomness ( or lack thereof ) of `malloc` things manifest randomly.

the original `pkg` uses `arc4random` with the correct size.